### PR TITLE
fix: import app object directly in run.py instead of string path

### DIFF
--- a/run.py
+++ b/run.py
@@ -1,4 +1,5 @@
+from backend.app.main import app
 import uvicorn
 
 if __name__ == "__main__":
-    uvicorn.run("backend.app.main:app", host="127.0.0.1", port=8000)
+    uvicorn.run(app, host="127.0.0.1", port=8000)


### PR DESCRIPTION
PyInstaller cannot trace string-based uvicorn imports at build time, causing ModuleNotFoundError for 'backend' at runtime. Passing the app object directly lets PyInstaller resolve all dependencies statically.

https://claude.ai/code/session_01Vs9DqVqazsH2v62imhXvtY