### PR TITLE
feat(OS-PMAS-USERS-01): user management for admins

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -13,7 +13,7 @@ from fastapi.staticfiles import StaticFiles
 from backend.app.database import DbSession, init_db
 from backend.app.deps import CurrentUser
 from backend.app.schemas import UploadOut
-from backend.app.routers import analytics, auth, cycles, dashboard, projects, ratecard, reference
+from backend.app.routers import analytics, auth, cycles, dashboard, projects, ratecard, reference, users
 from backend.app.services.ingestion import ClosedCycleError, ingest_file
 
 log = logging.getLogger(__name__)
@@ -47,6 +47,7 @@ app.add_middleware(
 )
 
 app.include_router(auth.router)
+app.include_router(users.router)
 app.include_router(cycles.router)
 app.include_router(projects.router)
 app.include_router(dashboard.router)

--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from backend.app.database import DbSession
+from backend.app.deps import AdminUser, CurrentUser, get_current_user
+from backend.app.models import User
+from backend.app.routers.auth import hash_password, verify_password
+from backend.app.schemas import PasswordChangeIn, UserCreateIn, UserOut
+
+router = APIRouter(
+    prefix="/api/users",
+    tags=["users"],
+    dependencies=[Depends(get_current_user)],
+)
+
+
+@router.get("", summary="Listar usuários", response_model=list[UserOut])
+def list_users(db: DbSession, _admin: AdminUser):
+    return db.query(User).order_by(User.username).all()
+
+
+@router.post("", summary="Criar usuário", status_code=201, response_model=UserOut)
+def create_user(body: UserCreateIn, db: DbSession, _admin: AdminUser):
+    if db.query(User).filter(User.username == body.username).first():
+        raise HTTPException(status_code=400, detail="Nome de usuário já existe.")
+    user = User(
+        username=body.username,
+        hashed_password=hash_password(body.password),
+        role=body.role,
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+@router.patch("/{user_id}/password", summary="Alterar senha", response_model=UserOut)
+def change_password(
+    user_id: int,
+    body: PasswordChangeIn,
+    db: DbSession,
+    current_user: CurrentUser,
+):
+    target = db.get(User, user_id)
+    if target is None:
+        raise HTTPException(status_code=404, detail="Usuário não encontrado.")
+    if current_user.role != "admin" and current_user.id != user_id:
+        raise HTTPException(status_code=403, detail="Sem permissão para alterar senha de outro usuário.")
+    if current_user.role != "admin":
+        if not body.current_password:
+            raise HTTPException(status_code=422, detail="Senha atual obrigatória.")
+        if not verify_password(body.current_password, target.hashed_password):
+            raise HTTPException(status_code=400, detail="Senha atual incorreta.")
+    target.hashed_password = hash_password(body.new_password)
+    db.commit()
+    db.refresh(target)
+    return target
+
+
+@router.delete("/{user_id}", summary="Excluir usuário", status_code=204)
+def delete_user(user_id: int, db: DbSession, admin: AdminUser):
+    target = db.get(User, user_id)
+    if target is None:
+        raise HTTPException(status_code=404, detail="Usuário não encontrado.")
+    if target.id == admin.id:
+        raise HTTPException(status_code=409, detail="Não é possível excluir o próprio usuário.")
+    db.delete(target)
+    db.commit()

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -39,6 +39,17 @@ class CollaboratorSeniorityIn(BaseModel):
     seniority_level_id: Optional[int] = None
 
 
+class UserCreateIn(BaseModel):
+    username: str = Field(min_length=3)
+    password: str = Field(min_length=6)
+    role: Literal["admin", "user"] = "user"
+
+
+class PasswordChangeIn(BaseModel):
+    new_password: str = Field(min_length=6)
+    current_password: Optional[str] = None
+
+
 # ── Output schemas ───────────────────────────────────────────────────────────
 
 class IdOut(BaseModel):

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -16,6 +16,7 @@ tabBtns.forEach(btn => {
     if (btn.dataset.tab === 'cycles')   loadCyclesTable();
     if (btn.dataset.tab === 'projects') loadProjectsTable();
     if (btn.dataset.tab === 'team')     loadTeamTab();
+    if (btn.dataset.tab === 'admin')    loadUsersTable();
   });
 });
 
@@ -1287,9 +1288,98 @@ document.getElementById('logoutBtn').addEventListener('click', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Users management (Admin tab)
+// ---------------------------------------------------------------------------
+let _allUsers = [];
+
+async function loadUsersTable() {
+  try {
+    _allUsers = await apiFetch('/api/users');
+    _renderUsersTable(_allUsers);
+  } catch (e) { notify(`Erro: ${e.message}`, 'error'); }
+}
+
+function _renderUsersTable(users) {
+  const tbody = document.getElementById('usersBody');
+  if (!users.length) {
+    tbody.innerHTML = '<tr><td colspan="3" style="text-align:center;color:#475569;padding:2rem">Nenhum usuário encontrado.</td></tr>';
+    return;
+  }
+  const payload = _getTokenPayload();
+  const selfId  = payload ? payload.sub : null;
+  tbody.innerHTML = users.map(u => `
+    <tr>
+      <td>${escHtml(u.username)}</td>
+      <td><span class="badge-status ${u.role === 'admin' ? 'ativo' : 'quarantine'}">${u.role === 'admin' ? 'Admin' : 'Usuário'}</span></td>
+      <td><div class="actions">
+        <button class="btn btn-secondary btn-sm" onclick="openPwdModal(${u.id})">Senha</button>
+        ${u.username !== selfId ? `<button class="btn btn-danger btn-sm" onclick="deleteUser(${u.id}, ${escHtml(JSON.stringify(u.username))})">Excluir</button>` : ''}
+      </div></td>
+    </tr>`).join('');
+}
+
+document.getElementById('newUserBtn').addEventListener('click', () => {
+  document.getElementById('userUsernameInput').value = '';
+  document.getElementById('userPasswordInput').value = '';
+  document.getElementById('userRoleSelect').value    = 'user';
+  document.getElementById('userError').textContent   = '';
+  document.getElementById('userModal').hidden = false;
+});
+
+document.getElementById('userModalClose').addEventListener('click',  () => { document.getElementById('userModal').hidden = true; });
+document.getElementById('userCancelBtn').addEventListener('click',   () => { document.getElementById('userModal').hidden = true; });
+
+document.getElementById('userSaveBtn').addEventListener('click', async () => {
+  const username = document.getElementById('userUsernameInput').value.trim();
+  const password = document.getElementById('userPasswordInput').value;
+  const role     = document.getElementById('userRoleSelect').value;
+  const errEl    = document.getElementById('userError');
+  errEl.textContent = '';
+  if (!username || !password) { errEl.textContent = 'Preencha todos os campos obrigatórios.'; return; }
+  try {
+    await apiFetchJSON('/api/users', 'POST', { username, password, role });
+    document.getElementById('userModal').hidden = true;
+    loadUsersTable();
+    notify(`Usuário "${escHtml(username)}" criado com sucesso.`, 'success');
+  } catch (e) { errEl.textContent = e.message; }
+});
+
+function openPwdModal(userId) {
+  document.getElementById('pwdTargetId').value  = userId;
+  document.getElementById('pwdNewInput').value  = '';
+  document.getElementById('pwdError').textContent = '';
+  document.getElementById('pwdModal').hidden = false;
+}
+
+document.getElementById('pwdModalClose').addEventListener('click', () => { document.getElementById('pwdModal').hidden = true; });
+document.getElementById('pwdCancelBtn').addEventListener('click',  () => { document.getElementById('pwdModal').hidden = true; });
+
+document.getElementById('pwdSaveBtn').addEventListener('click', async () => {
+  const userId      = document.getElementById('pwdTargetId').value;
+  const new_password = document.getElementById('pwdNewInput').value;
+  const errEl       = document.getElementById('pwdError');
+  errEl.textContent = '';
+  if (!new_password) { errEl.textContent = 'Informe a nova senha.'; return; }
+  try {
+    await apiFetchJSON(`/api/users/${userId}/password`, 'PATCH', { new_password });
+    document.getElementById('pwdModal').hidden = true;
+    notify('Senha alterada com sucesso.', 'success');
+  } catch (e) { errEl.textContent = e.message; }
+});
+
+async function deleteUser(id, username) {
+  if (!confirm(`Excluir o usuário "${username}"?`)) return;
+  try {
+    await apiFetchJSON(`/api/users/${id}`, 'DELETE');
+    loadUsersTable();
+  } catch (e) { notify(`Erro: ${e.message}`, 'error'); }
+}
+
+// ---------------------------------------------------------------------------
 // Boot
 // ---------------------------------------------------------------------------
 function _bootApp() {
+  if (_isAdmin()) document.getElementById('adminTabBtn').removeAttribute('hidden');
   loadDashboardCycles();
   _renderActiveTab();
 }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -43,6 +43,7 @@
   <button class="tab-btn" data-tab="cycles">Ciclos</button>
   <button class="tab-btn" data-tab="projects">Projetos</button>
   <button class="tab-btn" data-tab="team">Equipe</button>
+  <button class="tab-btn" data-tab="admin" id="adminTabBtn" hidden>Admin</button>
 </nav>
 
 <main>
@@ -264,6 +265,28 @@
 
   </section>
 
+  <!-- ================================================================== -->
+  <!-- TAB: Admin                                                           -->
+  <!-- ================================================================== -->
+  <section id="tab-admin" class="tab-section" hidden>
+    <div class="card">
+      <div class="section-header">
+        <h2 class="card-title">Gestão de Usuários</h2>
+        <button class="btn btn-primary btn-sm" id="newUserBtn">+ Novo usuário</button>
+      </div>
+      <table class="data-table" id="usersTable">
+        <thead>
+          <tr>
+            <th>Usuário</th>
+            <th>Perfil</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody id="usersBody"><tr><td colspan="3" style="text-align:center;color:#475569;padding:2rem">Carregando…</td></tr></tbody>
+      </table>
+    </div>
+  </section>
+
 </main>
 
 <!-- ================================================================== -->
@@ -434,6 +457,64 @@
 </div>
 
 </div><!-- /appShell -->
+
+<!-- ================================================================== -->
+<!-- Modal: Novo Usuário                                                  -->
+<!-- ================================================================== -->
+<div class="modal-backdrop" id="userModal" hidden>
+  <div class="modal-box">
+    <div class="modal-header">
+      <h3>Novo Usuário</h3>
+      <button class="modal-close" id="userModalClose">×</button>
+    </div>
+    <div class="form-grid cols-1">
+      <div class="form-group">
+        <label for="userUsernameInput">Usuário *</label>
+        <input type="text" id="userUsernameInput" placeholder="mínimo 3 caracteres" autocomplete="off" />
+      </div>
+      <div class="form-group">
+        <label for="userPasswordInput">Senha *</label>
+        <input type="password" id="userPasswordInput" placeholder="mínimo 6 caracteres" autocomplete="new-password" />
+      </div>
+      <div class="form-group">
+        <label for="userRoleSelect">Perfil</label>
+        <select class="form-select" id="userRoleSelect">
+          <option value="user">Usuário</option>
+          <option value="admin">Admin</option>
+        </select>
+      </div>
+    </div>
+    <div class="error-msg" id="userError"></div>
+    <div class="modal-footer">
+      <button class="btn btn-secondary" id="userCancelBtn">Cancelar</button>
+      <button class="btn btn-primary" id="userSaveBtn">Salvar</button>
+    </div>
+  </div>
+</div>
+
+<!-- ================================================================== -->
+<!-- Modal: Alterar Senha                                                 -->
+<!-- ================================================================== -->
+<div class="modal-backdrop" id="pwdModal" hidden>
+  <div class="modal-box">
+    <div class="modal-header">
+      <h3>Alterar Senha</h3>
+      <button class="modal-close" id="pwdModalClose">×</button>
+    </div>
+    <div class="form-grid cols-1">
+      <input type="hidden" id="pwdTargetId" />
+      <div class="form-group">
+        <label for="pwdNewInput">Nova senha *</label>
+        <input type="password" id="pwdNewInput" placeholder="mínimo 6 caracteres" autocomplete="new-password" />
+      </div>
+    </div>
+    <div class="error-msg" id="pwdError"></div>
+    <div class="modal-footer">
+      <button class="btn btn-secondary" id="pwdCancelBtn">Cancelar</button>
+      <button class="btn btn-primary" id="pwdSaveBtn">Salvar</button>
+    </div>
+  </div>
+</div>
 
 <script src="multiselect.js"></script>
 <script src="app.js"></script>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,7 +45,7 @@ def create_tables():
     Base.metadata.drop_all(bind=_ENGINE)
 
 
-_MOCK_ADMIN = User(id=1, username="test_admin", hashed_password="", role="admin")
+_MOCK_ADMIN = User(id=9999, username="test_admin", hashed_password="", role="admin")
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.app.deps import get_current_user
+from backend.app.main import app
+from backend.app.models import User
+from backend.app.routers.auth import hash_password
+
+
+def _make_user(db_session, username: str, password: str = "pass123", role: str = "user") -> User:
+    u = User(username=username, hashed_password=hash_password(password), role=role)
+    db_session.add(u)
+    db_session.commit()
+    db_session.refresh(u)
+    return u
+
+
+@contextmanager
+def _acting_as(user: User):
+    """Temporarily impersonate *user* for one TestClient block."""
+    saved = dict(app.dependency_overrides)
+    app.dependency_overrides[get_current_user] = lambda: user
+    with TestClient(app, raise_server_exceptions=True) as c:
+        yield c
+    app.dependency_overrides.clear()
+    app.dependency_overrides.update(saved)
+
+
+# ---------------------------------------------------------------------------
+# GET /api/users
+# ---------------------------------------------------------------------------
+
+class TestListUsers:
+    def test_empty(self, client):
+        assert client.get("/api/users").json() == []
+
+    def test_returns_created_user(self, client, db_session):
+        _make_user(db_session, "alice")
+        names = [u["username"] for u in client.get("/api/users").json()]
+        assert "alice" in names
+
+    def test_hashed_password_not_exposed(self, client, db_session):
+        _make_user(db_session, "bob")
+        data = client.get("/api/users").json()
+        assert all("hashed_password" not in u for u in data)
+
+    def test_non_admin_forbidden(self, db_session):
+        regular = _make_user(db_session, "carol")
+        with _acting_as(regular) as c:
+            assert c.get("/api/users").status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# POST /api/users
+# ---------------------------------------------------------------------------
+
+class TestCreateUser:
+    def test_success(self, client):
+        r = client.post("/api/users", json={"username": "dave", "password": "pass123"})
+        assert r.status_code == 201
+        d = r.json()
+        assert d["username"] == "dave"
+        assert d["role"] == "user"
+        assert "hashed_password" not in d
+
+    def test_default_role_is_user(self, client):
+        r = client.post("/api/users", json={"username": "eve", "password": "pass123"})
+        assert r.json()["role"] == "user"
+
+    def test_can_create_admin(self, client):
+        r = client.post("/api/users", json={"username": "frank", "password": "pass123", "role": "admin"})
+        assert r.status_code == 201
+        assert r.json()["role"] == "admin"
+
+    def test_duplicate_username_rejected(self, client, db_session):
+        _make_user(db_session, "grace")
+        r = client.post("/api/users", json={"username": "grace", "password": "pass123"})
+        assert r.status_code == 400
+
+    def test_short_username_rejected(self, client):
+        r = client.post("/api/users", json={"username": "ab", "password": "pass123"})
+        assert r.status_code == 422
+
+    def test_short_password_rejected(self, client):
+        r = client.post("/api/users", json={"username": "henry", "password": "12345"})
+        assert r.status_code == 422
+
+    def test_non_admin_forbidden(self, db_session):
+        regular = _make_user(db_session, "iris")
+        with _acting_as(regular) as c:
+            r = c.post("/api/users", json={"username": "newguy", "password": "pass123"})
+        assert r.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# PATCH /api/users/{id}/password
+# ---------------------------------------------------------------------------
+
+class TestChangePassword:
+    def test_admin_changes_any_password_without_current(self, client, db_session):
+        target = _make_user(db_session, "jack", "oldpass")
+        r = client.patch(f"/api/users/{target.id}/password", json={"new_password": "newpass123"})
+        assert r.status_code == 200
+
+    def test_user_changes_own_password_with_correct_current(self, db_session):
+        regular = _make_user(db_session, "karen", "oldpass")
+        with _acting_as(regular) as c:
+            r = c.patch(f"/api/users/{regular.id}/password",
+                        json={"new_password": "newpass123", "current_password": "oldpass"})
+        assert r.status_code == 200
+
+    def test_user_wrong_current_password_rejected(self, db_session):
+        regular = _make_user(db_session, "leo", "oldpass")
+        with _acting_as(regular) as c:
+            r = c.patch(f"/api/users/{regular.id}/password",
+                        json={"new_password": "newpass123", "current_password": "wrong"})
+        assert r.status_code == 400
+
+    def test_user_missing_current_password_rejected(self, db_session):
+        regular = _make_user(db_session, "mia", "oldpass")
+        with _acting_as(regular) as c:
+            r = c.patch(f"/api/users/{regular.id}/password",
+                        json={"new_password": "newpass123"})
+        assert r.status_code == 422
+
+    def test_user_cannot_change_others_password(self, db_session):
+        regular = _make_user(db_session, "ned", "pass")
+        other   = _make_user(db_session, "ola", "pass")
+        with _acting_as(regular) as c:
+            r = c.patch(f"/api/users/{other.id}/password",
+                        json={"new_password": "newpass123", "current_password": "pass"})
+        assert r.status_code == 403
+
+    def test_not_found(self, client):
+        r = client.patch("/api/users/99999/password", json={"new_password": "newpass123"})
+        assert r.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# DELETE /api/users/{id}
+# ---------------------------------------------------------------------------
+
+class TestDeleteUser:
+    def test_success(self, client, db_session):
+        u = _make_user(db_session, "pete")
+        assert client.delete(f"/api/users/{u.id}").status_code == 204
+
+    def test_not_found(self, client):
+        assert client.delete("/api/users/99999").status_code == 404
+
+    def test_deleted_not_in_list(self, client, db_session):
+        u = _make_user(db_session, "quinn")
+        client.delete(f"/api/users/{u.id}")
+        names = [x["username"] for x in client.get("/api/users").json()]
+        assert "quinn" not in names
+
+    def test_cannot_delete_self(self, db_session):
+        admin = _make_user(db_session, "selfdelete", role="admin")
+        with _acting_as(admin) as c:
+            r = c.delete(f"/api/users/{admin.id}")
+        assert r.status_code == 409
+
+    def test_non_admin_forbidden(self, db_session):
+        regular = _make_user(db_session, "rosa")
+        victim  = _make_user(db_session, "sam")
+        with _acting_as(regular) as c:
+            r = c.delete(f"/api/users/{victim.id}")
+        assert r.status_code == 403


### PR DESCRIPTION
Backend:
- GET/POST /api/users — admin-only list and create
- PATCH /api/users/{id}/password — any user changes own (current_password required); admin changes any without current_password
- DELETE /api/users/{id} — admin-only; self-delete returns 409
- UserCreateIn (min_length validation) + PasswordChangeIn schemas
- _MOCK_ADMIN.id bumped to 9999 to avoid collision with test-created users

Frontend:
- "Admin" tab hidden until _bootApp() confirms _isAdmin() via JWT payload
- Users table with role badge, change-password and delete buttons
- Self-delete button suppressed (username matches JWT sub)
- New-user modal + change-password modal reusing existing CSS classes

Tests: 22 new tests across 4 classes (list, create, change-password, delete)
Total: 151 passing

https://claude.ai/code/session_01Vs9DqVqazsH2v62imhXvtY