### PR TITLE
feat: radar chart (horas e custo por PEP) na aba Esforço da Equipe

### DIFF
--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -10,8 +10,8 @@ from sqlalchemy.orm import Session
 
 from backend.app.database import DbSession
 from backend.app.deps import get_current_user
-from backend.app.models import Collaborator, Cycle, Project, TimesheetRecord
-from backend.app.schemas import DashboardOut
+from backend.app.models import Collaborator, Cycle, GlobalConfig, Project, TimesheetRecord
+from backend.app.schemas import DashboardOut, PepRadarItem
 
 router = APIRouter(prefix="/api/dashboard", tags=["dashboard"], dependencies=[Depends(get_current_user)])
 
@@ -119,6 +119,74 @@ def _base_query(db: Session):
         func.sum(TimesheetRecord.extra_hours).label("extra_hours"),
         func.sum(TimesheetRecord.standby_hours).label("standby_hours"),
     ).join(Collaborator, TimesheetRecord.collaborator_id == Collaborator.id)
+
+
+@router.get("/pep-radar", summary="Horas e custo por PEP (descrição) para radar chart", response_model=list[PepRadarItem])
+def get_pep_radar(
+    db: DbSession,
+    cycle_id: Optional[int] = None,
+    pep_code: List[str] = Query(default=[]),
+    pep_description: List[str] = Query(default=[]),
+    collaborator_id: List[int] = Query(default=[]),
+    date_from: Optional[DateType] = None,
+    date_to: Optional[DateType] = None,
+):
+    cfg = db.get(GlobalConfig, 1)
+    em = cfg.extra_hours_multiplier if cfg else 1.5
+    sm = cfg.standby_hours_multiplier if cfg else 1.0
+
+    q = (
+        db.query(
+            TimesheetRecord.pep_description,
+            func.sum(
+                TimesheetRecord.normal_hours
+                + TimesheetRecord.extra_hours
+                + TimesheetRecord.standby_hours
+            ).label("total_hours"),
+            func.sum(
+                TimesheetRecord.cost_per_hour * (
+                    TimesheetRecord.normal_hours
+                    + TimesheetRecord.extra_hours * em
+                    + TimesheetRecord.standby_hours * sm
+                )
+            ).label("actual_cost"),
+        )
+        .filter(TimesheetRecord.pep_description.isnot(None))
+    )
+
+    if cycle_id is not None:
+        q = q.filter(TimesheetRecord.cycle_id == cycle_id)
+    if pep_code:
+        q = q.filter(TimesheetRecord.pep_wbs.in_(pep_code))
+    if pep_description:
+        q = q.filter(TimesheetRecord.pep_description.in_(pep_description))
+    if collaborator_id:
+        q = q.filter(TimesheetRecord.collaborator_id.in_(collaborator_id))
+    if date_from is not None:
+        q = q.filter(TimesheetRecord.record_date >= date_from)
+    if date_to is not None:
+        q = q.filter(TimesheetRecord.record_date <= date_to)
+
+    rows = (
+        q.group_by(TimesheetRecord.pep_description)
+        .order_by(
+            func.sum(
+                TimesheetRecord.normal_hours
+                + TimesheetRecord.extra_hours
+                + TimesheetRecord.standby_hours
+            ).desc()
+        )
+        .limit(12)
+        .all()
+    )
+    return [
+        {
+            "pep_description": r.pep_description,
+            "total_hours": round(r.total_hours or 0.0, 2),
+            "actual_cost": round(r.actual_cost or 0.0, 2),
+        }
+        for r in rows
+    ]
 
 
 @router.get("", summary="Dashboard sem filtro de ciclo — toda a base", response_model=DashboardOut)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -206,6 +206,12 @@ class UploadOut(BaseModel):
     quarantine_cycles_created: int
 
 
+class PepRadarItem(BaseModel):
+    pep_description: str
+    total_hours: float
+    actual_cost: float
+
+
 # Auth
 
 class Token(BaseModel):

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -29,7 +29,7 @@ const _charts = {};
 
 // Which chart IDs belong to each sub-tab (to dispose on leave)
 const CHARTS_PER_TAB = {
-  effort:    ['effortChart', 'budgetChart'],
+  effort:    ['effortChart', 'budgetChart', 'radarChart'],
   portfolio: ['treemapChart', 'bulletChart'],
   trends:    ['trendsChart'],
 };
@@ -304,6 +304,23 @@ async function _renderEffortTab() {
     } else {
       document.getElementById('budgetPanel').hidden = true;
     }
+
+    // Radar chart
+    const rp = new URLSearchParams(p);
+    if (cycleIds.length > 0) rp.set('cycle_id', cycleIds[0]);
+    const radarItems = await apiFetch(`/api/dashboard/pep-radar?${rp}`).catch(() => []);
+    if (radarItems.length >= 3) {
+      document.getElementById('radarPanel').hidden = false;
+      const rc = _getOrCreateChart('radarChart');
+      rc.setOption(_buildRadarOption(radarItems), true);
+      rc.resize();
+    } else {
+      document.getElementById('radarPanel').hidden = true;
+      if (_charts['radarChart'] && !_charts['radarChart'].isDisposed()) {
+        _charts['radarChart'].dispose();
+        delete _charts['radarChart'];
+      }
+    }
   } catch (err) { notify(`Erro: ${err.message}`, 'error'); }
 }
 
@@ -530,6 +547,64 @@ function _buildBudgetOption(budgetData) {
       { name: 'Orçado',    type: 'bar', data: budgets, itemStyle: { color: '#22d3ee' }, barMaxWidth: 28, barGap: '10%' },
       { name: 'Realizado', type: 'bar', data: actuals,                                  barMaxWidth: 28, barGap: '10%' },
     ],
+  };
+}
+
+function _buildRadarOption(items) {
+  const maxH = Math.max(...items.map(d => d.total_hours), 1);
+  const maxC = Math.max(...items.map(d => d.actual_cost), 1);
+  const fmtR = v => 'R$ ' + Number(v).toLocaleString('pt-BR', { minimumFractionDigits: 2 });
+  return {
+    backgroundColor: 'transparent',
+    legend: {
+      data: ['Horas', 'Custo (R$)'],
+      bottom: 4,
+      textStyle: { color: '#cbd5e1', fontSize: 12 },
+      itemGap: 24,
+    },
+    tooltip: {
+      trigger: 'item',
+      backgroundColor: '#1e293b', borderColor: '#475569', textStyle: { color: '#e2e8f0' },
+      formatter: params => {
+        const isCost = params.name === 'Custo (R$)';
+        let html = `<b>${escHtml(params.name)}</b><br>`;
+        (params.data.value || []).forEach((_, i) => {
+          if (i >= items.length) return;
+          const d = items[i];
+          const raw = isCost ? fmtR(d.actual_cost) : `${d.total_hours.toFixed(1)}h`;
+          html += `<span style="color:#94a3b8">${escHtml(d.pep_description)}</span>: <b>${raw}</b><br>`;
+        });
+        return html;
+      },
+    },
+    radar: {
+      indicator: items.map(d => ({ name: d.pep_description, max: 100 })),
+      center: ['50%', '50%'],
+      radius: '60%',
+      axisName: { color: '#94a3b8', fontSize: 10 },
+      splitLine: { lineStyle: { color: '#334155' } },
+      splitArea: { areaStyle: { color: ['rgba(30,41,59,0.4)', 'rgba(30,41,59,0.1)'] } },
+      axisLine: { lineStyle: { color: '#475569' } },
+    },
+    series: [{
+      type: 'radar',
+      data: [
+        {
+          name: 'Horas',
+          value: items.map(d => +(d.total_hours / maxH * 100).toFixed(1)),
+          itemStyle: { color: '#3b82f6' },
+          lineStyle: { color: '#3b82f6', width: 2 },
+          areaStyle: { color: 'rgba(59,130,246,0.15)' },
+        },
+        {
+          name: 'Custo (R$)',
+          value: items.map(d => +(d.actual_cost / maxC * 100).toFixed(1)),
+          itemStyle: { color: '#f59e0b' },
+          lineStyle: { color: '#f59e0b', width: 2 },
+          areaStyle: { color: 'rgba(245,158,11,0.15)' },
+        },
+      ],
+    }],
   };
 }
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -109,6 +109,13 @@
         <div class="panel-title">Orçado vs. Realizado por PEP</div>
         <div id="budgetChart" style="width:100%;height:300px"></div>
       </div>
+      <div class="card chart-panel" id="radarPanel" hidden>
+        <div class="panel-header">
+          <span class="panel-title">Horas e Custo por PEP — Radar</span>
+          <span class="panel-note">Valores normalizados · passe o mouse para ver totais absolutos</span>
+        </div>
+        <div id="radarChart" style="width:100%;height:440px"></div>
+      </div>
     </div>
 
     <!-- ============================================================ -->

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -200,3 +200,60 @@ class TestTrends:
         names_to_hours = {r["cycle_name"]: r["normal_hours"] for r in result}
         assert names_to_hours["MA1"] == 6.0
         assert names_to_hours["MA2"] == 9.0
+
+
+# ===========================================================================
+# /api/dashboard/pep-radar
+# ===========================================================================
+
+class TestPepRadar:
+    def test_empty(self, client):
+        assert client.get("/api/dashboard/pep-radar").json() == []
+
+    def test_returns_hours_and_cost_per_pep_description(self, client, db_session):
+        cy = _cycle(db_session, "R1", 2026, 1)
+        co = _collab(db_session, "Ana")
+        _rec(db_session, cy, co, "P1", desc="Alpha", normal=8.0)
+        _rec(db_session, cy, co, "P2", desc="Beta",  normal=4.0)
+        result = client.get("/api/dashboard/pep-radar").json()
+        descs = {r["pep_description"] for r in result}
+        assert descs == {"Alpha", "Beta"}
+
+    def test_sorted_desc_by_hours(self, client, db_session):
+        cy = _cycle(db_session, "R2", 2026, 2)
+        co = _collab(db_session, "Bob")
+        _rec(db_session, cy, co, "P1", desc="Low",  normal=2.0)
+        _rec(db_session, cy, co, "P2", desc="High", normal=10.0)
+        result = client.get("/api/dashboard/pep-radar").json()
+        assert result[0]["pep_description"] == "High"
+        assert result[1]["pep_description"] == "Low"
+
+    def test_excludes_records_without_pep_description(self, client, db_session):
+        cy = _cycle(db_session, "R3", 2026, 3)
+        co = _collab(db_session, "Carl")
+        r = TimesheetRecord(
+            collaborator_id=co.id, cycle_id=cy.id,
+            record_date=date(2026, 3, 5),
+            pep_wbs=None, pep_description=None,
+            normal_hours=8.0, extra_hours=0.0, standby_hours=0.0, cost_per_hour=0.0,
+        )
+        db_session.add(r); db_session.commit()
+        assert client.get("/api/dashboard/pep-radar").json() == []
+
+    def test_filter_by_cycle_id(self, client, db_session):
+        c1 = _cycle(db_session, "R4a", 2026, 4)
+        c2 = _cycle(db_session, "R4b", 2026, 5)
+        co = _collab(db_session, "Diana")
+        _rec(db_session, c1, co, "P1", desc="Want",   normal=8.0)
+        _rec(db_session, c2, co, "P2", desc="Ignore", normal=5.0)
+        result = client.get(f"/api/dashboard/pep-radar?cycle_id={c1.id}").json()
+        assert len(result) == 1
+        assert result[0]["pep_description"] == "Want"
+
+    def test_limits_to_12_peps(self, client, db_session):
+        cy = _cycle(db_session, "R5", 2026, 6)
+        co = _collab(db_session, "Eve")
+        for i in range(15):
+            _rec(db_session, cy, co, f"P{i}", desc=f"Desc{i}", normal=float(i + 1))
+        result = client.get("/api/dashboard/pep-radar").json()
+        assert len(result) == 12


### PR DESCRIPTION
- Novo endpoint GET /api/dashboard/pep-radar: agrega por pep_description, retorna total_hours e actual_cost (com multiplicadores GlobalConfig), limitado às 12 PEPs com mais horas, respeita todos os filtros do dashboard
- Painel radarPanel exibido abaixo do budgetPanel quando há ≥ 3 PEPs com descrição
- Duas séries normalizadas (0-100%) para comparar horas e custo na mesma escala visual; tooltip mostra valores absolutos (h / R$)
- 6 novos testes em TestPepRadar

https://claude.ai/code/session_01Vs9DqVqazsH2v62imhXvtY