### PR TITLE
fix(ui): corrige 3 defeitos no gráfico de esforço e tendências

### DIFF
--- a/docs/treinamento.md
+++ b/docs/treinamento.md
@@ -429,14 +429,14 @@ flowchart TD
 
 **O que você verá no final de Q2 (acumulado Jan–Jun):**
 
-| Projeto | Horas consumidas (aprox.) | Orçamento (h) | % consumido |
+| Projeto | Horas consumidas | Orçamento (h) | % consumido |
 |---|---|---|---|
-| CRM | ~1.768 h | 2.800 h | ~63% |
-| INF | ~1.274 h | 1.800 h | ~71% |
-| RH | ~520 h | 600 h | ~87% |
-| BI | ~624 h | 3.000 h | ~21% |
+| CRM | 1.632 h | 2.800 h | 58% |
+| INF | 1.159 h | 1.800 h | 64% |
+| RH | 498 h | 600 h | 83% |
+| BI | 536 h | 3.000 h | 18% |
 
-> **Sinal de alerta:** O INF já consumiu 71% do orçamento no meio do ano. O RH está em 87% — risco de estouro. Discuta ações corretivas com o grupo.
+> **Sinal de alerta:** O INF já consumiu 64% do orçamento no meio do ano. O RH está em 83% — risco de estouro se o ritmo continuar. Discuta ações corretivas com o grupo.
 
 ---
 
@@ -506,10 +506,10 @@ flowchart LR
 
 | Projeto | Consumido (h) | Orçamento (h) | % | Status |
 |---|---|---|---|---|
-| CRM | ~2.704 h | 2.800 h | ~97% | ⚠️ Atenção |
-| INF | ~2.002 h | 1.800 h | ~111% | 🔴 Estourado |
-| RH | ~520 h | 600 h | ~87% | ✅ Dentro |
-| BI | ~1.144 h | 3.000 h | ~38% | ✅ Saudável |
+| CRM | 2.520 h | 2.800 h | 90% | ⚠️ Atenção |
+| INF | 1.852 h | 1.800 h | 103% | 🔴 Estourado |
+| RH | 498 h | 600 h | 83% | ✅ Dentro |
+| BI | 1.008 h | 3.000 h | 34% | ✅ Saudável |
 
 > **Badge visual:** O PMAS exibe badges coloridos na tabela de projetos:
 > - 🔴 **Estourado** (≥ 100% do orçamento)
@@ -591,18 +591,18 @@ gantt
 
 ### 4.4 Resumo de Desempenho ao Final do Ano
 
-| Projeto | Horas consumidas | Orçamento | Custo real (aprox.) | Orçamento R$ | CPI |
+| Projeto | Horas consumidas | Orçamento | Custo real | Orçamento R$ | CPI |
 |---|---|---|---|---|---|
-| CRM | ~3.088 h | 2.800 h | ~R$ 290.000 | R$ 300.000 | ~1,03 |
-| INF | ~2.098 h | 1.800 h | ~R$ 178.000 | R$ 160.000 | **~0,90** |
-| RH | ~520 h | 600 h | ~R$ 33.000 | R$ 40.000 | ~1,21 |
-| BI | ~2.488 h | 3.000 h | ~R$ 175.000 | R$ 250.000 | ~1,43 |
+| CRM | 2.896 h | 2.800 h | R$ 297.360 | R$ 300.000 | 1,04 |
+| INF | 1.948 h | 1.800 h | R$ 156.270 | R$ 160.000 | **1,11** |
+| RH | 498 h | 600 h | R$ 30.660 | R$ 40.000 | 1,08 |
+| BI | 2.264 h | 3.000 h | R$ 215.680 | R$ 250.000 | **0,87** |
 
 > **Interpretação:**
-> - CRM: entregue com custo dentro do orçamento (CPI ≈ 1,0) — **sucesso**
-> - INF: estouro de custo, CPI < 1 — **lição aprendida**: necessidade de revisão de escopo em Q2
-> - RH: projeto suspenso saudável (CPI > 1) — **decisão correta de suspensão**
-> - BI: projeto em crescimento saudável, CPI excelente — **candidato a expansão em 2026**
+> - CRM: leve estouro de horas (103%), mas custo dentro do orçamento (CPI=1,04) — **sucesso**
+> - INF: estouro de horas (108%) porém custo abaixo do orçamento (CPI=1,11) — a equipe júnior durante a crise foi mais barata que o previsto, **mas o prazo sofreu impacto**
+> - RH: projeto suspenso com 83% das horas e custo sob controle (CPI=1,08) — **decisão correta de suspensão**
+> - BI: horas dentro do orçamento (75%) mas custo acima do esperado (CPI=0,87) — equipe sênior consumiu mais R$ por hora que o planejado; **monitorar em 2026**
 
 ---
 

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1212,9 +1212,7 @@ function _buildEffortOption(data, stacked) {
       containLabel: true,
     },
 
-    toolbox: _toolbox({
-      magicType: { type: ['stack', 'tiled'], title: { stack: 'Empilhado', tiled: 'Lado a Lado' } },
-    }),
+    toolbox: _toolbox(),
 
     tooltip: {
       trigger: 'axis',
@@ -1354,8 +1352,11 @@ function _buildEffortOption(data, stacked) {
           position: 'right',
           fontSize: 10,
           fontWeight: 600,
-          color: p => p.value === maxTotal ? '#f87171' : '#10b981',
-          formatter: p => `${p.value.toFixed(1)}h`,
+          color: '#10b981',
+          formatter: p => p.value === maxTotal
+            ? `{peak|${p.value.toFixed(1)}h}`
+            : `${p.value.toFixed(1)}h`,
+          rich: { peak: { color: '#f87171', fontWeight: 700 } },
         },
         z: 10,
       },
@@ -1939,7 +1940,9 @@ async function _openCollabTimelineModal(collaboratorName) {
         return html;
       },
     },
-    toolbox: _toolbox(),
+    toolbox: _toolbox({
+      magicType: { type: ['stack', 'tiled'], title: { stack: 'Empilhado', tiled: 'Lado a Lado' } },
+    }),
     xAxis: {
       type: 'category',
       data: cycles,


### PR DESCRIPTION
- Remove magicType stack/tiled do toolbox do gráfico de barras de esforço
- Adiciona magicType stack/tiled ao toolbox do gráfico de evolução por ciclo
- Corrige cor dos labels da linha Total: substitui callback (não suportado em label.color do ECharts) por cor estática #10b981; pico usa rich text para manter o destaque em vermelho sem depender de callback

docs: corrige dados divergentes no treinamento.md

- Tabela Q2 (Jan-Jun): atualizada com valores reais dos CSVs CRM 1.632h/58%, INF 1.159h/64%, RH 498h/83%, BI 536h/18%
- Tabela Q3 (Jan-Set): CRM 2.520h/90%, INF 1.852h/103%, BI 1.008h/34%, RH 498h/83%
- Tabela anual: CRM 2.896h/R$297k/CPI=1,04; INF 1.948h/R$156k/CPI=1,11; RH 498h/R$30,6k/CPI=1,08; BI 2.264h/R$215k/CPI=0,87
- Interpreta corretamente que INF é crise de prazo (horas) e BI é crise de custo (equipe sênior acima do planejado)

https://claude.ai/code/session_01Vs9DqVqazsH2v62imhXvtY