### PR TITLE
feat(issue-77): implement item 7 — dynamic palette, Aparência panel, …

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1191,15 +1191,17 @@ function _buildForecastOption(fc) {
     ? [...history.map(h => h.cumulative_planned_hours ?? null), ...Array(projCount).fill(null)]
     : null;
 
+  const _fpal = _getPalette();
+  const _fC0  = _fpal[0] || '#0ea5e9';
   const series = [
     {
       name: _t('forecast.realized'),
       type: 'line', yAxisIndex: 0,
       data: realizedData,
       smooth: false, symbol: 'circle', symbolSize: 6,
-      lineStyle: { color: '#0ea5e9', width: 2.5 },
-      itemStyle: { color: '#0ea5e9' },
-      areaStyle: { color: 'rgba(14,165,233,0.10)' },
+      lineStyle: { color: _fC0, width: 2.5 },
+      itemStyle: { color: _fC0 },
+      areaStyle: { color: _fC0 + '1a' },
       connectNulls: false,
     },
     {
@@ -1213,13 +1215,14 @@ function _buildForecastOption(fc) {
     },
   ];
   if (pvData) {
+    const _fC3 = _fpal[3] || '#a78bfa';
     series.push({
       name: _t('forecast.pv_line'),
       type: 'line', yAxisIndex: 0,
       data: pvData,
       symbol: 'none',
-      lineStyle: { color: '#a78bfa', width: 2, type: 'dotted' },
-      itemStyle: { color: '#a78bfa' },
+      lineStyle: { color: _fC3, width: 2, type: 'dotted' },
+      itemStyle: { color: _fC3 },
       connectNulls: true,
     });
   }
@@ -1590,10 +1593,11 @@ function _buildHoursBarOption({
     },
   });
 
+  const _pal = _getPalette();
   const barSeries = [
-    _barSerie(_t('ch.normal_h'),  normals,   '#3b82f6'),
-    _barSerie(_t('ch.extra_h'),   extras,    '#f59e0b'),
-    _barSerie(_t('ch.standby_h'), standbys,  '#8b5cf6'),
+    _barSerie(_t('ch.normal_h'),  normals,   _pal[0] || '#3b82f6'),
+    _barSerie(_t('ch.extra_h'),   extras,    _pal[1] || '#f59e0b'),
+    _barSerie(_t('ch.standby_h'), standbys,  _pal[2] || '#8b5cf6'),
   ];
 
   // ── 6. Série de linha de total (opcional) ───────────────────────────
@@ -2155,16 +2159,12 @@ function _buildCpiOption(trends) {
   };
 }
 
-const _PEP_CPI_COLORS = [
-  '#3b82f6', '#f59e0b', '#10b981', '#a78bfa',
-  '#f43f5e', '#06b6d4', '#fb923c', '#84cc16',
-];
-
 function _buildPepCpiOption(peps, allCycleNames) {
   const series = peps.map(([wbs, { desc, points }], i) => {
     const dataMap = Object.fromEntries(points.map(p => [p.cycleName, p.cpi]));
     const data    = allCycleNames.map(n => dataMap[n] ?? null);
-    const color   = _PEP_CPI_COLORS[i % _PEP_CPI_COLORS.length];
+    const pal     = _getPalette();
+    const color   = pal[i % pal.length];
     return {
       name: `${wbs} — ${desc}`,
       type: 'line',
@@ -3260,6 +3260,21 @@ async function _loadTheme() {
 // ---------------------------------------------------------------------------
 let _currentUserInfo = null;
 
+function _switchMyTab(tabId) {
+  document.querySelectorAll('.my-tab-btn').forEach(btn => {
+    btn.classList.toggle('active', btn.dataset.myTab === tabId);
+  });
+  document.querySelectorAll('.my-tab-section').forEach(el => {
+    el.hidden = el.id !== `my-tab-${tabId}`;
+  });
+  if (tabId === 'history')    loadMyHistory();
+  if (tabId === 'quarantine') loadMyQr();
+}
+
+document.querySelectorAll('.my-tab-btn').forEach(btn => {
+  btn.addEventListener('click', () => _switchMyTab(btn.dataset.myTab));
+});
+
 function _initMyArea() {
   const usernameEl = document.getElementById('myProfileUsername');
   if (usernameEl) {
@@ -3388,6 +3403,114 @@ document.getElementById('myPwdSaveBtn')?.addEventListener('click', async () => {
 });
 
 // ---------------------------------------------------------------------------
+// My Area — Upload sub-tab
+// ---------------------------------------------------------------------------
+document.getElementById('myAreaCsvInput')?.addEventListener('change', async (e) => {
+  const file = e.target.files[0];
+  if (!file) return;
+  const resultEl = document.getElementById('myAreaUploadResult');
+  resultEl.textContent = _t('loading');
+  try {
+    const fd = new FormData();
+    fd.append('file', file);
+    const resp = await fetch('/api/upload-timesheet', {
+      method: 'POST',
+      headers: { 'Authorization': `Bearer ${sessionStorage.getItem('access_token')}` },
+      body: fd,
+    });
+    const json = await resp.json();
+    if (!resp.ok) throw new Error(json.detail || resp.statusText);
+    let msg = `✅ ${json.records_inserted} ${_t('upload.inserted')}`;
+    if (json.records_skipped)          msg += ` · ${json.records_skipped} ${_t('upload.skipped')}`;
+    if (json.quarantine_records_added) msg += ` · ⚠ ${json.quarantine_records_added} ${_t('upload.quarantine')}`;
+    if (json.warning_count)            msg += ` · ${json.warning_count} ${_t('upload.warnings')}`;
+    resultEl.textContent = msg;
+    notify(msg, json.quarantine_records_added ? 'warning' : 'success');
+  } catch (e) {
+    resultEl.textContent = `Erro: ${e.message}`;
+    notify(e.message, 'error');
+  }
+  e.target.value = '';
+});
+
+// ---------------------------------------------------------------------------
+// My Area — Histórico sub-tab
+// ---------------------------------------------------------------------------
+async function loadMyHistory() {
+  try {
+    const rows = await apiFetch('/api/my/upload-history');
+    _renderMyHistory(rows);
+  } catch (e) { notify(`Erro: ${e.message}`, 'error'); }
+}
+
+function _renderMyHistory(rows) {
+  const tbody = document.getElementById('myHistoryBody');
+  if (!tbody) return;
+  if (!rows.length) {
+    tbody.innerHTML = `<tr><td colspan="7" style="text-align:center;color:#475569;padding:2rem">Nenhuma importação registrada.</td></tr>`;
+    return;
+  }
+  tbody.innerHTML = rows.map(r => {
+    const when = new Date(r.uploaded_at).toLocaleString('pt-BR', { dateStyle: 'short', timeStyle: 'short' });
+    const statusKey = r.status === 'ok' ? 'history.status.ok'
+      : r.status === 'warnings' ? 'history.status.warnings'
+      : r.status === 'quarantine' ? 'history.status.quarantine'
+      : 'history.status.rejected';
+    return `<tr>
+      <td style="white-space:nowrap;font-size:.78rem">${escHtml(when)}</td>
+      <td style="font-size:.78rem">${escHtml(r.source_file)}</td>
+      <td style="text-align:right">${r.records_inserted}</td>
+      <td style="text-align:right">${r.records_skipped}</td>
+      <td style="text-align:right">${r.quarantine_added}</td>
+      <td style="text-align:right">${r.warning_count}</td>
+      <td>${escHtml(_t(statusKey))}</td>
+    </tr>`;
+  }).join('');
+}
+
+document.getElementById('myHistoryRefreshBtn')?.addEventListener('click', loadMyHistory);
+
+// ---------------------------------------------------------------------------
+// My Area — Quarentena sub-tab
+// ---------------------------------------------------------------------------
+async function loadMyQr() {
+  const filter = document.getElementById('myQrFilter')?.value;
+  const params = new URLSearchParams({ limit: 200 });
+  if (filter === 'pending')   params.set('review_status', 'pending');
+  if (filter === 'approved')  params.set('review_status', 'approved');
+  if (filter === 'rejected')  params.set('review_status', 'rejected');
+  try {
+    const rows = await apiFetch(`/api/my/quarantine?${params}`);
+    _renderMyQrTable(rows);
+  } catch (e) { notify(`Erro: ${e.message}`, 'error'); }
+}
+
+function _renderMyQrTable(rows) {
+  const tbody = document.getElementById('myQrBody');
+  if (!tbody) return;
+  if (!rows.length) {
+    tbody.innerHTML = `<tr><td colspan="6" style="text-align:center;color:#475569;padding:2rem">Nenhum registro em quarentena.</td></tr>`;
+    return;
+  }
+  tbody.innerHTML = rows.map(r => {
+    const raw  = r.raw_data || {};
+    const when = new Date(r.ingested_at).toLocaleString('pt-BR', { dateStyle: 'short', timeStyle: 'short' });
+    return `<tr>
+      <td style="font-size:.78rem;white-space:nowrap">${escHtml(when)}</td>
+      <td>${escHtml(raw['Colaborador'] || '—')}</td>
+      <td style="text-align:right">${raw['Horas totais (decimal)'] ?? '—'}</td>
+      <td style="font-size:.78rem">${escHtml(raw['Código PEP'] || '—')}</td>
+      <td style="font-size:.78rem;max-width:220px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap"
+          title="${escHtml(r.quarantine_reason)}">${escHtml(r.quarantine_reason)}</td>
+      <td>${_qrStatusBadge(r.review_status)}</td>
+    </tr>`;
+  }).join('');
+}
+
+document.getElementById('myQrRefreshBtn')?.addEventListener('click', loadMyQr);
+document.getElementById('myQrFilter')?.addEventListener('change', loadMyQr);
+
+// ---------------------------------------------------------------------------
 // Validation Rules (Admin tab)
 // ---------------------------------------------------------------------------
 let _rules = [];
@@ -3450,6 +3573,25 @@ function _renderRulesList() {
   });
 }
 
+const _AGGREGATE_RULE_FIELDS = new Set(['soma_diaria', 'soma_semanal']);
+
+function _updateRuleActionOptions() {
+  const field     = document.getElementById('ruleFieldInput')?.value;
+  const actionSel = document.getElementById('ruleActionInput');
+  const hintEl    = document.getElementById('ruleAggregateHint');
+  if (!actionSel) return;
+  const isAgg = _AGGREGATE_RULE_FIELDS.has(field);
+  [...actionSel.options].forEach(opt => {
+    if (opt.value === 'quarentena' || opt.value === 'descarte') {
+      opt.disabled = isAgg;
+    }
+  });
+  if (isAgg && (actionSel.value === 'quarentena' || actionSel.value === 'descarte')) {
+    actionSel.value = 'warning';
+  }
+  if (hintEl) hintEl.hidden = !isAgg;
+}
+
 function _openRuleModal(rule = null) {
   _editingRuleId = rule ? rule.id : null;
   document.getElementById('ruleModalTitle').textContent = rule ? 'Editar Regra' : 'Nova Regra de Validação';
@@ -3461,6 +3603,7 @@ function _openRuleModal(rule = null) {
   document.getElementById('ruleActiveInput').value   = rule ? (rule.is_active ? 'true' : 'false') : 'true';
   document.getElementById('ruleDescInput').value     = rule?.description || '';
   document.getElementById('ruleError').textContent   = '';
+  _updateRuleActionOptions();
   document.getElementById('ruleModal').removeAttribute('hidden');
 }
 
@@ -3469,6 +3612,7 @@ function openEditRule(id) {
   if (rule) _openRuleModal(rule);
 }
 
+document.getElementById('ruleFieldInput')?.addEventListener('change', _updateRuleActionOptions);
 document.getElementById('newRuleBtn')?.addEventListener('click', () => _openRuleModal());
 document.getElementById('ruleModalClose')?.addEventListener('click',  () => document.getElementById('ruleModal').setAttribute('hidden', ''));
 document.getElementById('ruleCancelBtn')?.addEventListener('click',   () => document.getElementById('ruleModal').setAttribute('hidden', ''));
@@ -3665,25 +3809,121 @@ async function _loadThemeEditor() {
   } catch (e) { notify(`Erro ao carregar tema: ${e.message}`, 'error'); }
 }
 
+function _applyThemePreset(key) {
+  const preset = _THEME_PRESETS[key];
+  if (!preset) return;
+  _THEME_FIELDS.forEach(f => {
+    if (preset[f.key]) {
+      const picker = document.getElementById(`themeColor_${f.key}`);
+      const txt    = document.getElementById(`themeColorTxt_${f.key}`);
+      if (picker) picker.value = preset[f.key];
+      if (txt)    txt.value   = preset[f.key];
+    }
+  });
+  if (preset.density) {
+    document.querySelectorAll('.theme-density-btn').forEach(btn => {
+      btn.classList.toggle('active', btn.dataset.density === preset.density);
+    });
+  }
+  if (preset.chart_palette) {
+    preset.chart_palette.forEach((c, i) => {
+      const picker = document.getElementById(`themePalColor_${i}`);
+      const txt    = document.getElementById(`themePalTxt_${i}`);
+      if (picker) picker.value = c;
+      if (txt)    txt.value   = c;
+    });
+  }
+}
+
 function _renderThemeEditor() {
   const grid = document.getElementById('themeColorGrid');
   if (!grid) return;
-  grid.innerHTML = _THEME_FIELDS.map(f => `
-    <div class="form-group">
-      <label style="font-size:.7rem;color:#94a3b8">${escHtml(f.label)}</label>
-      <div class="theme-swatch-row">
-        <input type="color" id="themeColor_${f.key}" value="${escHtml(_currentTheme[f.key] || '#000000')}" />
-        <input type="text" id="themeColorTxt_${f.key}" value="${escHtml(_currentTheme[f.key] || '')}" style="flex:1;font-size:.8rem" />
-      </div>
-    </div>
-  `).join('');
+  const t   = _currentTheme;
+  const pal = t.chart_palette?.length ? t.chart_palette : _THEME_PRESETS.pmas.chart_palette;
 
-  // Sync color picker ↔ text input
+  // Section: app name + density
+  const densitySection = `
+    <div class="form-group full" style="margin-bottom:.25rem">
+      <label style="font-size:.75rem;font-weight:600;color:#cbd5e1">${_t('appearance.app_name')}</label>
+      <input type="text" id="themeAppName" value="${escHtml(t.app_name || 'PMAS')}"
+        style="max-width:240px;margin-top:.25rem" />
+    </div>
+    <div class="form-group full" style="margin-bottom:.5rem">
+      <label style="font-size:.75rem;font-weight:600;color:#cbd5e1">${_t('appearance.density')}</label>
+      <div style="display:flex;gap:.5rem;margin-top:.25rem">
+        ${['compact','normal','relaxed'].map(d => `
+          <button class="btn btn-secondary btn-sm theme-density-btn${(t.density || 'normal') === d ? ' active' : ''}"
+            data-density="${d}" type="button">${_t('appearance.density.'+d)}</button>
+        `).join('')}
+      </div>
+    </div>`;
+
+  // Section: presets
+  const presetsSection = `
+    <div class="form-group full" style="margin-bottom:.5rem">
+      <label style="font-size:.75rem;font-weight:600;color:#cbd5e1">${_t('appearance.presets')}</label>
+      <div style="display:flex;gap:.5rem;flex-wrap:wrap;margin-top:.25rem">
+        ${Object.keys(_THEME_PRESETS).map(k => `
+          <button class="btn btn-secondary btn-sm" type="button"
+            onclick="_applyThemePreset('${k}')">${_t('appearance.preset.'+k)}</button>
+        `).join('')}
+      </div>
+    </div>`;
+
+  // Section: colors
+  const colorSection = `
+    <div class="form-group full" style="margin-bottom:.25rem">
+      <label style="font-size:.75rem;font-weight:600;color:#cbd5e1">${_t('appearance.colors')}</label>
+    </div>
+    ${_THEME_FIELDS.map(f => `
+      <div class="form-group">
+        <label style="font-size:.7rem;color:#94a3b8">${escHtml(f.label)}</label>
+        <div class="theme-swatch-row">
+          <input type="color" id="themeColor_${f.key}" value="${escHtml(t[f.key] || '#000000')}" />
+          <input type="text" id="themeColorTxt_${f.key}" value="${escHtml(t[f.key] || '')}"
+            style="flex:1;font-size:.8rem" />
+        </div>
+      </div>
+    `).join('')}`;
+
+  // Section: chart palette
+  const paletteSection = `
+    <div class="form-group full" style="margin:.5rem 0 .25rem">
+      <label style="font-size:.75rem;font-weight:600;color:#cbd5e1">${_t('appearance.palette')}</label>
+    </div>
+    ${Array.from({ length: 6 }, (_, i) => `
+      <div class="form-group">
+        <label style="font-size:.7rem;color:#94a3b8">Cor ${i + 1}</label>
+        <div class="theme-swatch-row">
+          <input type="color" id="themePalColor_${i}" value="${escHtml(pal[i] || '#4f8ef7')}" />
+          <input type="text" id="themePalTxt_${i}" value="${escHtml(pal[i] || '')}"
+            style="flex:1;font-size:.8rem" />
+        </div>
+      </div>
+    `).join('')}`;
+
+  grid.innerHTML = densitySection + presetsSection + colorSection + paletteSection;
+
+  // Wire color pickers ↔ text inputs
   _THEME_FIELDS.forEach(f => {
     const picker = document.getElementById(`themeColor_${f.key}`);
     const txt    = document.getElementById(`themeColorTxt_${f.key}`);
     picker?.addEventListener('input', () => { txt.value = picker.value; });
-    txt?.addEventListener('change', () => { picker.value = txt.value; });
+    txt?.addEventListener('change',  () => { if (/^#[0-9a-f]{6}$/i.test(txt.value)) picker.value = txt.value; });
+  });
+  Array.from({ length: 6 }, (_, i) => {
+    const picker = document.getElementById(`themePalColor_${i}`);
+    const txt    = document.getElementById(`themePalTxt_${i}`);
+    picker?.addEventListener('input', () => { txt.value = picker.value; });
+    txt?.addEventListener('change',  () => { if (/^#[0-9a-f]{6}$/i.test(txt.value)) picker.value = txt.value; });
+  });
+
+  // Density button toggle
+  grid.querySelectorAll('.theme-density-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      grid.querySelectorAll('.theme-density-btn').forEach(b => b.classList.remove('active'));
+      btn.classList.add('active');
+    });
   });
 }
 
@@ -3693,11 +3933,22 @@ document.getElementById('saveThemeBtn')?.addEventListener('click', async () => {
     const txt = document.getElementById(`themeColorTxt_${f.key}`);
     if (txt) payload[f.key] = txt.value;
   });
+  const appNameEl = document.getElementById('themeAppName');
+  if (appNameEl) payload.app_name = appNameEl.value.trim() || 'PMAS';
+  const activeBtn = document.querySelector('.theme-density-btn.active');
+  if (activeBtn) payload.density = activeBtn.dataset.density;
+  payload.chart_palette = Array.from({ length: 6 }, (_, i) => {
+    return document.getElementById(`themePalTxt_${i}`)?.value || _THEME_PRESETS.pmas.chart_palette[i];
+  });
   try {
     _currentTheme = await apiFetchJSON('/api/theme', 'PUT', payload);
     _loadTheme();
-    notify('Tema salvo.', 'success');
+    notify(_t('appearance.saved'), 'success');
   } catch (e) { notify(`Erro: ${e.message}`, 'error'); }
+});
+
+document.getElementById('restoreDefaultThemeBtn')?.addEventListener('click', () => {
+  _applyThemePreset('pmas');
 });
 
 document.getElementById('logoUploadInput')?.addEventListener('change', async (e) => {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -439,39 +439,116 @@
   <!-- TAB: Minha Área                                                     -->
   <!-- ================================================================== -->
   <section id="tab-my" class="tab-section" hidden>
-    <div class="my-area-grid">
 
-      <!-- Profile card -->
-      <div class="card">
-        <h2 class="card-title">Meu Perfil</h2>
-        <p id="myProfileUsername" style="font-size:.9rem;margin-bottom:1rem;color:#94a3b8"></p>
-        <button class="btn btn-secondary btn-sm" id="myChangePwdBtn">Alterar senha</button>
-      </div>
+    <nav class="my-area-nav">
+      <button class="my-tab-btn active" data-my-tab="profile">Perfil</button>
+      <button class="my-tab-btn" data-my-tab="upload" data-i18n="myarea.upload">Upload</button>
+      <button class="my-tab-btn" data-my-tab="history" data-i18n="myarea.history">Histórico</button>
+      <button class="my-tab-btn" data-my-tab="quarantine" data-i18n="myarea.quarantine">Quarentena</button>
+    </nav>
 
-      <!-- Dashboard layout customization -->
-      <div class="card">
-        <div class="section-header" style="margin-bottom:.75rem">
-          <h2 class="card-title" style="margin-bottom:0">Layout do Dashboard</h2>
-          <button class="btn btn-primary btn-sm" id="saveLayoutBtn">Salvar layout</button>
+    <!-- Sub-tab: Perfil -->
+    <div id="my-tab-profile" class="my-tab-section">
+      <div class="my-area-grid">
+
+        <!-- Profile card -->
+        <div class="card">
+          <h2 class="card-title">Meu Perfil</h2>
+          <p id="myProfileUsername" style="font-size:.9rem;margin-bottom:1rem;color:#94a3b8"></p>
+          <button class="btn btn-secondary btn-sm" id="myChangePwdBtn">Alterar senha</button>
         </div>
-        <p style="font-size:.75rem;color:#64748b;margin-bottom:.75rem">Arraste para reordenar os painéis do dashboard.</p>
-        <ul class="sortable-list" id="chartLayoutList">
-          <li class="sortable-item" data-chart="effort">
-            <span class="sortable-handle">⠿</span>
-            <span class="sortable-item-label">Esforço da Equipe</span>
-          </li>
-          <li class="sortable-item" data-chart="portfolio">
-            <span class="sortable-handle">⠿</span>
-            <span class="sortable-item-label">Saúde do Portfólio</span>
-          </li>
-          <li class="sortable-item" data-chart="forecast">
-            <span class="sortable-handle">⠿</span>
-            <span class="sortable-item-label">Previsão (EVM)</span>
-          </li>
-        </ul>
-      </div>
 
+        <!-- Dashboard layout customization -->
+        <div class="card">
+          <div class="section-header" style="margin-bottom:.75rem">
+            <h2 class="card-title" style="margin-bottom:0">Layout do Dashboard</h2>
+            <button class="btn btn-primary btn-sm" id="saveLayoutBtn">Salvar layout</button>
+          </div>
+          <p style="font-size:.75rem;color:#64748b;margin-bottom:.75rem">Arraste para reordenar os painéis do dashboard.</p>
+          <ul class="sortable-list" id="chartLayoutList">
+            <li class="sortable-item" data-chart="effort">
+              <span class="sortable-handle">⠿</span>
+              <span class="sortable-item-label">Esforço da Equipe</span>
+            </li>
+            <li class="sortable-item" data-chart="portfolio">
+              <span class="sortable-handle">⠿</span>
+              <span class="sortable-item-label">Saúde do Portfólio</span>
+            </li>
+            <li class="sortable-item" data-chart="forecast">
+              <span class="sortable-handle">⠿</span>
+              <span class="sortable-item-label">Previsão (EVM)</span>
+            </li>
+          </ul>
+        </div>
+
+      </div>
     </div>
+
+    <!-- Sub-tab: Upload -->
+    <div id="my-tab-upload" class="my-tab-section" hidden>
+      <div class="card" style="max-width:480px">
+        <h2 class="card-title" data-i18n="myarea.upload">Upload</h2>
+        <p style="font-size:.85rem;color:#94a3b8;margin-bottom:1rem">Importe um arquivo CSV ou XLSX de timesheets.</p>
+        <label class="btn btn-primary" style="cursor:pointer;display:inline-flex;align-items:center;gap:.5rem">
+          <span data-i18n="btn.import_ts">⬆ Importar</span>
+          <input type="file" id="myAreaCsvInput" accept=".csv,.xlsx,.xls" hidden />
+        </label>
+        <div id="myAreaUploadResult" style="margin-top:1rem;font-size:.85rem;color:#94a3b8"></div>
+      </div>
+    </div>
+
+    <!-- Sub-tab: Histórico -->
+    <div id="my-tab-history" class="my-tab-section" hidden>
+      <div class="card">
+        <div class="section-header">
+          <h2 class="card-title" data-i18n="myarea.history">Histórico de Importações</h2>
+          <button class="btn btn-secondary btn-sm" id="myHistoryRefreshBtn">↺ Atualizar</button>
+        </div>
+        <table class="data-table" id="myHistoryTable">
+          <thead><tr>
+            <th data-i18n="history.th.when">Quando</th>
+            <th data-i18n="history.th.file">Arquivo</th>
+            <th style="text-align:right" data-i18n="history.th.inserted">Inseridos</th>
+            <th style="text-align:right" data-i18n="history.th.skipped">Ignorados</th>
+            <th style="text-align:right" data-i18n="history.th.quarantine">Quarentena</th>
+            <th style="text-align:right" data-i18n="history.th.warnings">Avisos</th>
+            <th data-i18n="history.th.status">Status</th>
+          </tr></thead>
+          <tbody id="myHistoryBody"><tr><td colspan="7" style="text-align:center;color:#475569;padding:2rem" data-i18n="loading">Carregando…</td></tr></tbody>
+        </table>
+      </div>
+    </div>
+
+    <!-- Sub-tab: Quarentena -->
+    <div id="my-tab-quarantine" class="my-tab-section" hidden>
+      <div class="card">
+        <div class="section-header">
+          <h2 class="card-title" data-i18n="myarea.quarantine">Quarentena</h2>
+          <div style="display:flex;gap:.5rem;align-items:center">
+            <select id="myQrFilter" class="form-select" style="min-width:160px;height:2rem;font-size:.8rem">
+              <option value="">Todos os registros</option>
+              <option value="pending">⏳ Pendentes</option>
+              <option value="approved">✅ Aprovados</option>
+              <option value="rejected">❌ Rejeitados</option>
+            </select>
+            <button class="btn btn-secondary btn-sm" id="myQrRefreshBtn">↺ Atualizar</button>
+          </div>
+        </div>
+        <p style="font-size:.78rem;color:#94a3b8;margin:.25rem 0 .75rem">Registros do seus uploads que foram para quarentena.</p>
+        <table class="data-table" id="myQrTable">
+          <thead><tr>
+            <th data-i18n="qr.th.date">Data</th>
+            <th data-i18n="qr.th.collaborator">Colaborador</th>
+            <th style="text-align:right" data-i18n="qr.th.hours">Horas</th>
+            <th data-i18n="qr.th.pep">PEP</th>
+            <th data-i18n="qr.th.reason">Motivo</th>
+            <th>Status</th>
+          </tr></thead>
+          <tbody id="myQrBody"><tr><td colspan="6" style="text-align:center;color:#475569;padding:2rem" data-i18n="loading">Carregando…</td></tr></tbody>
+        </table>
+      </div>
+    </div>
+
   </section>
 
   <!-- ================================================================== -->
@@ -558,14 +635,15 @@
     <!-- Theme Editor -->
     <div class="card">
       <div class="section-header">
-        <h2 class="card-title">Aparência (Tema)</h2>
-        <div style="display:flex;gap:.5rem">
-          <label class="btn btn-secondary btn-sm" style="cursor:pointer" title="Enviar logo">
+        <h2 class="card-title" data-i18n="appearance.title">Aparência do Sistema</h2>
+        <div style="display:flex;gap:.5rem;flex-wrap:wrap">
+          <label class="btn btn-secondary btn-sm" style="cursor:pointer" title="Enviar logo" data-i18n="appearance.logo_upload">
             📷 Logo
             <input type="file" id="logoUploadInput" accept=".png,.jpg,.jpeg,.svg,.webp" hidden />
           </label>
-          <button class="btn btn-danger btn-sm" id="deleteLogoBtn">✕ Remover logo</button>
-          <button class="btn btn-primary btn-sm" id="saveThemeBtn">Salvar tema</button>
+          <button class="btn btn-danger btn-sm" id="deleteLogoBtn" data-i18n="appearance.logo_remove">✕ Remover logo</button>
+          <button class="btn btn-secondary btn-sm" id="restoreDefaultThemeBtn" data-i18n="appearance.restore">Restaurar padrões</button>
+          <button class="btn btn-primary btn-sm" id="saveThemeBtn" data-i18n="appearance.save">Salvar aparência</button>
         </div>
       </div>
       <div id="themePreviewBar" class="theme-preview-bar" style="margin-bottom:1rem"></div>
@@ -891,6 +969,7 @@
           <option value="quarentena">quarentena</option>
           <option value="descarte">descarte</option>
         </select>
+        <p id="ruleAggregateHint" hidden style="margin:.25rem 0 0;font-size:.75rem;color:#f59e0b" data-i18n="vr.hint.aggregate">Regras de agregado permitem apenas info ou warning.</p>
       </div>
       <div class="form-group">
         <label>Ordem</label>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -587,6 +587,18 @@ input[type="date"]::-webkit-calendar-picker-indicator:hover {
 }
 
 /* ── My Area tab ─────────────────────────────────────────────── */
+.my-area-nav {
+  display: flex; gap: .25rem; flex-wrap: wrap;
+  border-bottom: 1px solid var(--border); margin-bottom: 1.25rem;
+}
+.my-tab-btn {
+  padding: .45rem 1rem; font-size: .85rem; font-weight: 500;
+  background: none; border: none; border-bottom: 2px solid transparent;
+  color: var(--text-2); cursor: pointer; transition: color .15s, border-color .15s;
+}
+.my-tab-btn:hover { color: var(--text); }
+.my-tab-btn.active { color: var(--primary); border-bottom-color: var(--primary); }
+
 .my-area-grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
@@ -661,6 +673,9 @@ input[type="date"]::-webkit-calendar-picker-indicator:hover {
 .theme-preview-bar {
   height: 4px; border-radius: 2px; margin-top: 0.5rem;
   background: linear-gradient(90deg, var(--theme-primary), var(--theme-accent));
+}
+.theme-density-btn.active {
+  background: var(--primary); color: #fff; border-color: var(--primary);
 }
 
 /* ── Chart grid / card layout (data-driven) ─────────────────────────────── */


### PR DESCRIPTION
…Minha Área sub-tabs, aggregate rule guard

7.2: wire _getPalette() into bar chart (effortChart/trendsChart), PEP CPI lines
     and forecast realized/PV series — charts now respect the saved theme palette.

7.10: disable quarentena/descarte action options in rule modal when an aggregate
      field (soma_diaria, soma_semanal) is selected; shows inline hint.

7.11: rewrite _renderThemeEditor() to include app_name input, 3-button density
      selector, preset buttons (PMAS/Corporate/High-contrast), 6 chart-palette
      color swatches, and restore-defaults button; saveThemeBtn persists all
      new fields to /api/theme.

7.6/7.7/7.8: add sub-tab nav (Perfil/Upload/Histórico/Quarentena) to Minha Área;
             Upload tab triggers /api/upload-timesheet with inline result;
             Histórico calls /api/my/upload-history; Quarentena calls
             /api/my/quarantine with status filter.

https://claude.ai/code/session_01Vs9DqVqazsH2v62imhXvtY