### PR TITLE
Fix XLSX ingestion TypeError: pd.Timestamp not coerced to date

### DIFF
--- a/backend/app/services/ingestion.py
+++ b/backend/app/services/ingestion.py
@@ -516,8 +516,10 @@ def _resolve_cycle(db: Session, record_date: date) -> Cycle:
 
 
 def _parse_date(value) -> date:
+    if isinstance(value, pd.Timestamp):
+        return value.date()
     if isinstance(value, date):
-        return value
+        return value if type(value) is date else value.date()
     if isinstance(value, (int, float)):
         return date(1899, 12, 30) + timedelta(days=int(value))
     return pd.to_datetime(str(value), dayfirst=True).date()


### PR DESCRIPTION
pd.Timestamp is a subclass of datetime which is a subclass of date, so the isinstance(value, date) guard returned True and passed the raw Timestamp through to SQLAlchemy, which failed comparing it with Cycle.start_date / Cycle.end_date.

Fix: check for pd.Timestamp first and call .date() on it; also call .date() on any datetime subclass that isn't a plain date, so future datetime values are safe too. Bug only surfaced with XLSX files — CSV cells return strings and took the pd.to_datetime(...).date() path correctly. Fixes #90.

https://claude.ai/code/session_01Vs9DqVqazsH2v62imhXvtY