### PR TITLE
fix(calendar): restore missing lastDay declaration dropped in refactor

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -2912,6 +2912,7 @@ async function _renderCollabCalendar(name, year, month) {
   // data: [date, total, normal, extra, standby]
   // All days in the month — inactive days use value=-1 so visualMap.outOfRange
   // applies a neutral background while the label still shows the day number.
+  const lastDay    = new Date(year, month, 0).getDate();
   const allDaysData = [];
   for (let d = 1; d <= lastDay; d++) {
     const dateStr = `${year}-${String(month).padStart(2,'0')}-${String(d).padStart(2,'0')}`;


### PR DESCRIPTION
const lastDay = new Date(year, month, 0).getDate() was lost when the allDaysData block replaced the old calData block, causing a ReferenceError that prevented the calendar from rendering at all.

https://claude.ai/code/session_01Vs9DqVqazsH2v62imhXvtY